### PR TITLE
added ability to override options on a per-route basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,16 @@ router.use(reactExpressMiddleware({
   renderMethod: ReactDOM.render, // or ReactDOMServer.renderToString on the server
   template: 'index',  // template passed to express' render
   key: 'content' // the variable exposed to the express template engine with the rendered html string
-)}
+)});
+
+// Overriding options per route
+router.get('/', function () {
+  res.locals.reactExpressMiddlewareOptions = {
+    template: 'other-template'
+  };
+  // will use the template `other-template.html`
+  res.renderReactComponent(Foo);
+});
 
 // Using 'renderReactComponent' method.
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -19,12 +19,20 @@ export default function reactExpressMiddlewareGenerator (options = {}) {
 		return window.document.getElementById('app');
 	})(options.element);
 
+	// Allow for option overrides per-route
+	options.mergeOptions = typeof options.mergeOptions === 'function' ? options.mergeOptions : function (req, res) {
+		return Object.assign({}, options, res.locals.reactExpressMiddlewareOptions);
+	};
+
 	return function reactExpressMiddleware (req, res, next) {
 		res.renderReactComponent = function renderReactComponent (Component, store, done) {
 			if (typeof store === 'function') {
 				done = store;
 				store = undefined;
 			}
+
+			// Merge the route options
+			var opts = options.mergeOptions(req, res);
 
 			if (!Component.hasOwnProperty('$$typeof')) {
 				// store defaults to res.locals
@@ -41,7 +49,7 @@ export default function reactExpressMiddlewareGenerator (options = {}) {
 			}
 
 			// Render template with string
-			options.renderMethod(Component, options.element, done);
+			opts.renderMethod(Component, opts.element, done);
 		};
 		next();
 	};

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,7 @@ describe('React Express Middleware', function () {
 
 		// Create response
 		var res = {
+			locals: {},
 			render: function (path, data, doneRender) {
 				assert.equal(path, 'foo.html');
 				assert.equal(data.content, '<div><h1>Basic headline.</h1><p>Basic paragraph.</p></div>');
@@ -68,7 +69,9 @@ describe('React Express Middleware', function () {
 		});
 
 		// Create response
-		var res = {};
+		var res = {
+			locals: {}
+		};
 
 		// Run middleware (client)
 		renderMiddleware({}, res, function (err) {


### PR DESCRIPTION
Merges `res.locals.reactExpressMiddlewareOptions` into the original options passed to the middleware factory before processing render.

@amberleyromo can you take a look at this before we merge everything together?